### PR TITLE
Bugfix/headers not loading

### DIFF
--- a/lib/las_reader.rb
+++ b/lib/las_reader.rb
@@ -78,7 +78,7 @@ module LasReader
       return
     end
 
-    fld = info.match(/(FLD\s*\..+FIELD:\s*(.*))|(FLD\s*\.\s*(.*)\s+:\s*FIELD)/)
+    fld = info.match(/(FLD\s*\..+FIELD:\s*(.*))|(FLD\s*\.\s*(.*)\s*:\s*FIELD)/)
     unless fld.nil?
       @well_info.field_name = (fld[2] or fld[4]).strip
       return

--- a/lib/las_reader.rb
+++ b/lib/las_reader.rb
@@ -72,7 +72,7 @@ module LasReader
       return
     end
 
-    well = info.match(/(WELL\s*\..+WELL:\s*(.*))|(WELL\s*\.\s*(.*)\s+:\s*WELL)/)
+    well = info.match(/(WELL\s*\..+WELL:\s*(.*))|(WELL\s*\.\s*(.*)\s*:\s*WELL)/)
     unless well.nil?
       @well_info.well_name = (well[2] or well[4]).strip
       return

--- a/lib/las_reader.rb
+++ b/lib/las_reader.rb
@@ -17,7 +17,7 @@ module LasReader
     if version.nil?
       wrap_mode = info.match(/(WRAP\s*\.).+(YES|NO).*:\s*(.*)/)
       if not wrap_mode.nil?
-          @wrap =  (wrap_mode[2] == "YES") ? true : false
+        @wrap =  (wrap_mode[2] == "YES") ? true : false
       end
     else
       @version = version[2]
@@ -184,7 +184,7 @@ module LasReader
       next if line[0].chr == '#' 
       # The '~' is used to inform the beginning of a section
       if line[0].chr == '~' 
-          case line[1].chr
+        case line[1].chr
             when 'V' # Version information section
               read_state = 1 
             when 'W' # Well identification section
@@ -199,12 +199,12 @@ module LasReader
               read_state = 5 
             when 'A' # ASCII Log data section
               read_state = 6 
-          else
-            raise "unsupported file format for #{line}"
+            else
+              raise "unsupported file format for #{line}"
             read_state = 0 # Unknow file format
           end
-      else
-        case read_state
+        else
+          case read_state
           when 1
             set_version(line.lstrip)
           when 2
@@ -221,16 +221,16 @@ module LasReader
             else
               log_nowrap_data(line)
             end 
+          end
         end
       end
     end
+
   end
 
-end
+  class CWLSLas
 
-class CWLSLas
-
-  include LasReader
+    include LasReader
 
   # Initialize CWLSLas object passing las file as argument
   # 
@@ -324,7 +324,7 @@ class CWLSLas
   def location
     self.well_info.location
   end
- 
+
   # Returns the province described in the file 
   # 
   # Example:
@@ -390,6 +390,32 @@ class CWLSLas
 
   def state
     self.well_info.state
+  end
+
+  # Returns the county described in the file 
+  # 
+  # Example:
+  #   >> my_well = CWLSLas.new('my_well.las')
+  #   => #<CWLSLas>
+  #   >> my_well.county
+  #   => "KENAI"
+  #
+
+  def county
+    self.well_info.county
+  end
+
+  # Returns the country described in the file 
+  # 
+  # Example:
+  #   >> my_well = CWLSLas.new('my_well.las')
+  #   => #<CWLSLas>
+  #   >> my_well.country
+  #   => "US"
+  #
+
+  def country
+    self.well_info.country
   end
 
 end

--- a/lib/las_reader.rb
+++ b/lib/las_reader.rb
@@ -66,7 +66,7 @@ module LasReader
       return
     end
 
-    comp = info.match(/(COMP\s*\..+COMPANY:\s*(.*))|(COMP\s*\.\s*(.*)\s+:\s*COMPANY)/)
+    comp = info.match(/(COMP\s*\..+COMPANY:\s*(.*))|(COMP\s*\.\s*(.*)\s*:\s*COMPANY)/)
     unless comp.nil?
       @well_info.company_name = (comp[2] or comp[4]).strip
       return

--- a/lib/las_reader.rb
+++ b/lib/las_reader.rb
@@ -84,7 +84,7 @@ module LasReader
       return
     end
 
-    loc = info.match(/(LOC\s*\..+LOCATION:\s*(.*))|(LOC\s*\.\s*(.*)\s+:\s*LOCATION)/)
+    loc = info.match(/(LOC\s*\..+LOCATION:\s*(.*))|(LOC\s*\.\s*(.*)\s*:\s*LOCATION)/)
     unless loc.nil?
       @well_info.location = (loc[2] or loc[4]).strip
       return
@@ -369,6 +369,19 @@ class CWLSLas
 
   def uwi
     self.well_info.uwi
+  end
+
+  # Returns the state described in the file 
+  # 
+  # Example:
+  #   >> my_well = CWLSLas.new('my_well.las')
+  #   => #<CWLSLas>
+  #   >> my_well.state
+  #   => "KANSAS"
+  #
+
+  def state
+    self.well_info.state
   end
 
 end

--- a/lib/las_reader.rb
+++ b/lib/las_reader.rb
@@ -102,7 +102,7 @@ module LasReader
       return
     end
 
-    stat = info.match(/(STAT\s*\..+STATE:\s*(.*))|(STAT\s*\.\s*(.*)\s+:\s*STATE)/)
+    stat = info.match(/(STAT\s*\..+STATE:\s*(.*))|(STAT\s*\.\s*(.*)\s*:\s*STATE)/)
     unless stat.nil?
       @well_info.state = (stat[2] or stat[4]).strip
       return

--- a/lib/las_reader.rb
+++ b/lib/las_reader.rb
@@ -90,13 +90,13 @@ module LasReader
       return
     end
 
-    prov = info.match(/(PROV\s*\..+PROVINCE:\s*(.*))|(PROV\s*\.\s*(.*)\s+:\s*PROVINCE)/)
+    prov = info.match(/(PROV\s*\..+PROVINCE:\s*(.*))|(PROV\s*\.\s*(.*)\s*:\s*PROVINCE)/)
     unless prov.nil?
       @well_info.province = (prov[2] or prov[4]).strip
       return
     end
 
-    cnty = info.match(/(CNTY\s*\..+COUNTY:\s*(.*))|(CNTY\s*\.\s*(.*)\s+:\s*COUNTY)/)
+    cnty = info.match(/(CNTY\s*\..+COUNTY:\s*(.*))|(CNTY\s*\.\s*(.*)\s*:\s*COUNTY)/)
     unless cnty.nil?
       @well_info.county = (cnty[2] or cnty[4]).strip
       return
@@ -108,25 +108,25 @@ module LasReader
       return
     end
 
-    ctry  = info.match(/(CTRY\s*\..+COUNTRY:\s*(.*))|(CTRY\s*\.\s*(.*)\s+:\s*COUNTRY)/)
+    ctry  = info.match(/(CTRY\s*\..+COUNTRY:\s*(.*))|(CTRY\s*\.\s*(.*)\s*:\s*COUNTRY)/)
     unless ctry.nil?
       @well_info.country = (ctry[2] or ctry[4]).strip
       return
     end
 
-    srvc = info.match(/(SRVC\s*\..+SERVICE COMPANY:\s*(.*))|(SRVC\s*\.\s*(.*)\s+:\s*SERVICE COMPANY)/)
+    srvc = info.match(/(SRVC\s*\..+SERVICE COMPANY:\s*(.*))|(SRVC\s*\.\s*(.*)\s*:\s*SERVICE COMPANY)/)
     unless srvc.nil?
       @well_info.service_company = (srvc[2] or srvc[4]).strip
       return
     end
 
-    data = info.match(/(DATE\s*\..+LOG DATE:\s*(.*))|(DATE\s*\.\s*(.*)\s+:\s*LOG DATE)/)
+    data = info.match(/(DATE\s*\..+LOG DATE:\s*(.*))|(DATE\s*\.\s*(.*)\s*:\s*LOG DATE)/)
     unless data.nil?
       @well_info.date_logged = (data[2] or data[4]).strip
       return
     end
 
-    uwi = info.match(/(UWI\s*\..+UNIQUE WELL ID:\s*(.*))|(UWI\s*\.\s*(.*)\s+:\s*UNIQUE WELL ID)/)
+    uwi = info.match(/(UWI\s*\..+UNIQUE WELL ID:\s*(.*))|(UWI\s*\.\s*(.*)\s*:\s*UNIQUE WELL ID)/)
     unless uwi.nil?
       @well_info.uwi = (uwi[2] or uwi[4]).strip
       return

--- a/lib/las_reader.rb
+++ b/lib/las_reader.rb
@@ -132,6 +132,12 @@ module LasReader
       return
     end
 
+    api = info.match(/(API\s*\..+UNIQUE WELL ID\s*:\s*(.*))|(API\s*\.\s*(.*)\s*:\s*UNIQUE WELL ID\s*)/)
+    unless api.nil?
+      @well_info.api = (api[2] or api[4]).strip
+      return
+    end
+
   end
 
   def set_other_info(info)
@@ -358,8 +364,10 @@ class CWLSLas
     self.well_info.date_logged
   end
 
-  # Returns the UWI (UNIQUE WELL ID) described in the file 
+  # Returns the UWI (UNIQUE WELL ID) described in the file  
   # 
+  # Returns API if UWI not found (for locations outside Canada)
+  #
   # Example:
   #   >> my_well = CWLSLas.new('my_well.las')
   #   => #<CWLSLas>
@@ -368,7 +376,7 @@ class CWLSLas
   #
 
   def uwi
-    self.well_info.uwi
+    self.well_info.uwi || self.well_info.api
   end
 
   # Returns the state described in the file 

--- a/spec/las_reader_spec.rb
+++ b/spec/las_reader_spec.rb
@@ -190,7 +190,7 @@ describe "CWLS LAS reader" do
     end
   end
 
-  describe CWLSLas, "#province" do
+  describe CWLSLas, "#province/state" do
     context "get province from las v1.2 file 'example1.las'" do
       province = "SASKATCHEWAN"
       las = CWLSLas.new
@@ -254,6 +254,22 @@ describe "CWLS LAS reader" do
       las.load_file(file_path+'/example21.las')
       it { expect(las.uwi).to eq(uwi) }
     end
+    context "get unique well id (api for this file) from las v2.0 file 'example24_check.las'" do
+      uwi = "50883200850000"
+      las = CWLSLas.new
+      las.load_file(file_path+'/example24_check.las')
+      it { expect(las.uwi).to eq(uwi) }
+    end
   end
+
+  describe CWLSLas, "#county" do
+    context "get county from las v2.0 file 'example24_check.las'" do
+      county = "KENAI"
+      las = CWLSLas.new
+      las.load_file(file_path+'/example24_check.las')
+      it { expect(las.county).to eq(county) }
+    end
+  end
+
 
 end

--- a/spec/las_reader_spec.rb
+++ b/spec/las_reader_spec.rb
@@ -19,7 +19,7 @@ describe "CWLS LAS reader" do
     context "when loading LAS v1.2 file: 'example1.las'" do
         las = CWLSLas.new
         las.load_file(file_path+'/example1.las')
-        it { las.should be_true }
+        it { expect(las).to be_truthy }
     end
     context "when loading LAS v1.2 file: 'example2.las'" do
         las = CWLSLas.new

--- a/spec/las_reader_spec.rb
+++ b/spec/las_reader_spec.rb
@@ -139,6 +139,12 @@ describe "CWLS LAS reader" do
       las = CWLSLas.new
       las.load_file(file_path+'/example21.las')
       it { expect(las.company_name).to eq(company_name) }
+    end    
+    context "get company name from las v2.0 file 'example24_check.las'" do
+      company_name = "ARCO ALASKA INC"
+      las = CWLSLas.new
+      las.load_file(file_path+'/example24_check.las')
+      it { expect(las.company_name).to eq(company_name) }
     end
   end
 

--- a/spec/las_reader_spec.rb
+++ b/spec/las_reader_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-  
+
 describe "CWLS LAS reader" do
 
   file_path = File.expand_path(File.dirname(__FILE__) + '/fixtures/files/')
@@ -14,46 +14,46 @@ describe "CWLS LAS reader" do
       las = CWLSLas.new
       it { expect { las.load_file(file_path+'/LAS_30a_Revised_2010.las') }.to raise_error("LAS version not supported") } 
     end
-  
+
     # LAS v1.2   
     context "when loading LAS v1.2 file: 'example1.las'" do
-        las = CWLSLas.new
-        las.load_file(file_path+'/example1.las')
-        it { expect(las).to be_truthy }
+      las = CWLSLas.new
+      las.load_file(file_path+'/example1.las')
+      it { expect(las).to be_truthy }
     end
     context "when loading LAS v1.2 file: 'example2.las'" do
-        las = CWLSLas.new
-        las.load_file(file_path+'/example2.las')
-        it { expect(las).to be_truthy }
+      las = CWLSLas.new
+      las.load_file(file_path+'/example2.las')
+      it { expect(las).to be_truthy }
     end
     context "when loading LAS v1.2 file: 'example3.las'" do
-        las = CWLSLas.new
-        las.load_file(file_path+'/example3.las')
-        it { expect(las).to be_truthy }
+      las = CWLSLas.new
+      las.load_file(file_path+'/example3.las')
+      it { expect(las).to be_truthy }
     end
     
     # LAS v2.0   
     context "when loading LAS v2.0 file: 'example21.las'" do
-        las = CWLSLas.new
-        las.load_file(file_path+'/example21.las')
-        it { expect(las).to be_truthy }
+      las = CWLSLas.new
+      las.load_file(file_path+'/example21.las')
+      it { expect(las).to be_truthy }
     end
     context "when loading LAS v2.0 file: 'example22.las'" do
-        las = CWLSLas.new
-        las.load_file(file_path+'/example22.las')
-        it { expect(las).to be_truthy }
+      las = CWLSLas.new
+      las.load_file(file_path+'/example22.las')
+      it { expect(las).to be_truthy }
     end
     context "when loading LAS v2.0 file: 'example23.las'" do
-        las = CWLSLas.new
-        las.load_file(file_path+'/example23.las')
-        it { expect(las).to be_truthy }
-    end    
-    context "when loading LAS v2.0 file: 'example24_check.las'" do
-        las = CWLSLas.new
-        las.load_file(file_path+'/example24_check.las')
-        it { expect(las).to be_truthy }
+      las = CWLSLas.new
+      las.load_file(file_path+'/example23.las')
+      it { expect(las).to be_truthy }
     end
-  
+    context "when loading LAS v2.0 file: 'example24_check.las'" do
+      las = CWLSLas.new
+      las.load_file(file_path+'/example24_check.las')
+      it { expect(las).to be_truthy }
+    end
+
   end
   
   describe CWLSLas, "#curve_names" do
@@ -139,7 +139,7 @@ describe "CWLS LAS reader" do
       las = CWLSLas.new
       las.load_file(file_path+'/example21.las')
       it { expect(las.company_name).to eq(company_name) }
-    end    
+    end
     context "get company name from las v2.0 file 'example24_check.las'" do
       company_name = "ARCO ALASKA INC"
       las = CWLSLas.new
@@ -159,6 +159,12 @@ describe "CWLS LAS reader" do
       field_name = "WILDCAT"
       las = CWLSLas.new
       las.load_file(file_path+'/example21.las')
+      it { expect(las.field_name).to eq(field_name) }
+    end    
+    context "get company name from las v2.0 file 'example24_check.las'" do
+      field_name = "Mid Grd Shoal/Trdng Bay"
+      las = CWLSLas.new
+      las.load_file(file_path+'/example24_check.las')
       it { expect(las.field_name).to eq(field_name) }
     end
   end

--- a/spec/las_reader_spec.rb
+++ b/spec/las_reader_spec.rb
@@ -24,29 +24,29 @@ describe "CWLS LAS reader" do
     context "when loading LAS v1.2 file: 'example2.las'" do
         las = CWLSLas.new
         las.load_file(file_path+'/example2.las')
-        it { las.should be_true }
+        it { expect(las).to be_truthy }
     end
     context "when loading LAS v1.2 file: 'example3.las'" do
         las = CWLSLas.new
         las.load_file(file_path+'/example3.las')
-        it { las.should be_true }
+        it { expect(las).to be_truthy }
     end
     
     # LAS v2.0   
     context "when loading LAS v2.0 file: 'example21.las'" do
         las = CWLSLas.new
         las.load_file(file_path+'/example21.las')
-        it { las.should be_true }
+        it { expect(las).to be_truthy }
     end
     context "when loading LAS v2.0 file: 'example22.las'" do
         las = CWLSLas.new
         las.load_file(file_path+'/example22.las')
-        it { las.should be_true }
+        it { expect(las).to be_truthy }
     end
     context "when loading LAS v2.0 file: 'example23.las'" do
         las = CWLSLas.new
         las.load_file(file_path+'/example23.las')
-        it { las.should be_true }
+        it { expect(las).to be_truthy }
     end
   
   end
@@ -55,17 +55,17 @@ describe "CWLS LAS reader" do
     context "number of curves in file example1.las" do
       las = CWLSLas.new
       las.load_file(file_path+'/example1.las')
-      it { las.curve_names.size.should == 8 }
+      it { expect(las.curve_names.size).to eq(8) }
     end
     context "number of curves in file example2.las" do
       las = CWLSLas.new
       las.load_file(file_path+'/example2.las')
-      it { las.curve_names.size.should == 8 }
+      it { expect(las.curve_names.size).to eq(8) }
     end
     context "number of curves in file example3.las" do
       las = CWLSLas.new
       las.load_file(file_path+'/example3.las')
-      it { las.curve_names.size.should == 36 }
+      it { expect(las.curve_names.size).to eq(36) }
     end
   end
 

--- a/spec/las_reader_spec.rb
+++ b/spec/las_reader_spec.rb
@@ -119,6 +119,12 @@ describe "CWLS LAS reader" do
       las.load_file(file_path+'/example21.las')
       it { expect(las.well_name).to eq(well_name) }
     end
+    context "get well name from las v2.0 file 'example24_check.las'" do
+      well_name = "NORTH FORELAND ST #1"
+      las = CWLSLas.new
+      las.load_file(file_path+'/example24_check.las')
+      it { expect(las.well_name).to eq(well_name) }
+    end
   end
 
   describe CWLSLas, "#company_name" do

--- a/spec/las_reader_spec.rb
+++ b/spec/las_reader_spec.rb
@@ -47,6 +47,11 @@ describe "CWLS LAS reader" do
         las = CWLSLas.new
         las.load_file(file_path+'/example23.las')
         it { expect(las).to be_truthy }
+    end    
+    context "when loading LAS v2.0 file: 'example24_check.las'" do
+        las = CWLSLas.new
+        las.load_file(file_path+'/example24_check.las')
+        it { expect(las).to be_truthy }
     end
   
   end

--- a/spec/las_reader_spec.rb
+++ b/spec/las_reader_spec.rb
@@ -203,11 +203,11 @@ describe "CWLS LAS reader" do
       las.load_file(file_path+'/example21.las')
       it { expect(las.province).to eq(province) }
     end
-    context "get province from las v2.0 file 'example24_check.las'" do
-      province = "ALBERTA"
+    context "get state(American file) from las v2.0 file 'example24_check.las'" do
+      state = "Alaska"
       las = CWLSLas.new
       las.load_file(file_path+'/example24_check.las')
-      it { expect(las.province).to eq(province) }
+      it { expect(las.state).to eq(state) }
     end
   end
 

--- a/spec/las_reader_spec.rb
+++ b/spec/las_reader_spec.rb
@@ -71,6 +71,11 @@ describe "CWLS LAS reader" do
       las = CWLSLas.new
       las.load_file(file_path+'/example3.las')
       it { expect(las.curve_names.size).to eq(36) }
+    end    
+    context "number of curves in file example24_check.las" do
+      las = CWLSLas.new
+      las.load_file(file_path+'/example24_check.las')
+      it { expect(las.curve_names.size).to eq(18) }
     end
   end
 

--- a/spec/las_reader_spec.rb
+++ b/spec/las_reader_spec.rb
@@ -182,6 +182,12 @@ describe "CWLS LAS reader" do
       las.load_file(file_path+'/example21.las')
       it { expect(las.location).to eq(location) }
     end
+    context "get location from las v2.0 file 'example24_check.las'" do
+      location = "11N  10W   13 2242FNL 1240FWL"
+      las = CWLSLas.new
+      las.load_file(file_path+'/example24_check.las')
+      it { expect(las.location).to eq(location) }
+    end
   end
 
   describe CWLSLas, "#province" do
@@ -195,6 +201,12 @@ describe "CWLS LAS reader" do
       province = "ALBERTA"
       las = CWLSLas.new
       las.load_file(file_path+'/example21.las')
+      it { expect(las.province).to eq(province) }
+    end
+    context "get province from las v2.0 file 'example24_check.las'" do
+      province = "ALBERTA"
+      las = CWLSLas.new
+      las.load_file(file_path+'/example24_check.las')
       it { expect(las.province).to eq(province) }
     end
   end

--- a/spec/las_reader_spec.rb
+++ b/spec/las_reader_spec.rb
@@ -271,5 +271,14 @@ describe "CWLS LAS reader" do
     end
   end
 
+  describe CWLSLas, "#country" do
+    context "get country from las v2.0 file 'example24_check.las'" do
+      country = "US"
+      las = CWLSLas.new
+      las.load_file(file_path+'/example24_check.las')
+      it { expect(las.country).to eq(country) }
+    end
+  end
+
 
 end


### PR DESCRIPTION
Modified regex to accomodate no space convention in some American LAS file. Changed '\s+' to ' \s*' just before ':' in the well_info section. Added state, country and county methods for non-Canadian las files. Added API alternative when UWI not used (outside Canada)  Added corresponding tests.
